### PR TITLE
feat(ci): automatic releases

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,8 +21,10 @@
     "GOARCH",
     "GOARM",
     "armv",
+    "cocogitto",
     "commitlint",
     "golangci",
+    "goreleaser",
     "libc",
     "wagoid"
   ],

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,54 @@
+---
+# Update versions and create release PR
+# Source: https://www.thisdot.co/blog/tag-and-release-your-project-with-github-actions-workflows
+#
+# For detailed description see "release.yml"
+
+name: release-prepare
+on: workflow_dispatch
+
+permissions:
+  contents: write # To push new branch
+  pull-requests: write # To create a pull request
+
+jobs:
+  release-prepare:
+    name: version_bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Automatically determinate the next release version from Conventional Commits since the latest tag
+      - name: Get next version
+        id: semver
+        uses: ietf-tools/semver-action@v1
+        with:
+          token: ${{ github.token }}
+          branch: main
+
+      # Bump version
+      - name: Update main.go
+        run: |
+          sed -i -E 's/const bmcTestGoVersion = .*/const bmcTestGoVersion = "${{ steps.semver.outputs.next }}"/g' main.go
+
+      # Changelog
+      - name: Get cocogitto
+        run: |
+          cargo install --locked cocogitto
+      - name: Update changelog
+        run: |
+          cog changelog > CHANGELOG.md
+
+      - name: Create pull request
+        id: create_pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release/${{ steps.semver.outputs.next }}
+          commit-message: 'chore: bump version to ${{ steps.semver.outputs.next }}'
+          title: 'Release: ${{ steps.semver.outputs.next }} Pull Request'
+          body: 'Prepare for next release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+---
+# Update versions and create release PR
+# Source: https://www.thisdot.co/blog/tag-and-release-your-project-with-github-actions-workflows
+#         https://goreleaser.com/ci/actions/#tag-fetching
+#
+# - Manually triggered "release-prepare.yml" workflow will create a PR
+#   - This PR will do some minor tweaks to ready for release (such as increment the version across files)
+# - Upon merging the PR, "release" job defined here will trigger, which will:
+#   - create a tag
+#   - do the actual release with goreleaser
+
+name: release
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+jobs:
+  release-golang:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To create a new release
+    if: startsWith(github.event.pull_request.title, 'Release:') && github.event.pull_request.merged == true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Set up Git
+        run: |
+          git config user.name "Release bot"
+          git config user.email "releasebot@noreply.com"
+      - name: Get current version
+        id: get_version
+        run: |
+          git branch --show-current
+          git pull
+          echo "version=$(grep 'const bmcTestGoVersion' < main.go | sed -E 's/.*= "//g' | sed 's/"//g')" >> "${GITHUB_OUTPUT}"
+          # Can't really use cocogitto here
+
+      - name: Create tag
+        run: |
+          NEXT_VERSION=${{ steps.get_version.outputs.version }}
+          git pull
+          git tag -a "${NEXT_VERSION}" -m "${NEXT_VERSION}"
+          git push --follow-tags
+          git checkout "${NEXT_VERSION}"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,12 @@
 // Package main implements the core logic
 package main
 
-func main() {
+import (
+	"fmt"
+)
 
+const bmcTestGoVersion = "v0.0.0"
+
+func main() {
+	fmt.Println(bmcTestGoVersion)
 }


### PR DESCRIPTION
Lets do automatic releases.

This automation works as such:
- Go to GitHubs `actions` tab into `release-prepare` workflow and trigger it manually
- A new Pull Request will be created which prepares everything for the new release (increments version numbers, updates a `CHANGELOG.md`, and so on)
- Upon merging the PR, a new release will be automatically created in GitHub
- The next version is determined by commit history since last release (thanks to conventional commits)