### PR TITLE
fix README, fix config, nondefault redfish port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,69 @@
 # bmc-test-go
-bmc testing framework
 
-## Environment Variables for config
+`bmc-test-go` is a Go-based test framework for validating BMC and OpenBMC systems.
+It provides a command-line test runner, YAML-based device configuration, Redfish
+access through `gofish`, and local or SSH-based command execution on the BMC.
 
-The config parsing checks for the following environment variables:
-- IMAGE : The base image to check
-- GOLDEN_IMAGE : Known good image to downgrade to
-- BMC_SSH_KEY : SSH Key for bmc root user
-- HOST_SSH_KEY : SSH Key for the host root user
+## Dependencies (Arch Linux)
 
-If the configuration file has the environment variable set, but the value is empty, the parser detects an error.
+```sh
+sudo pacman -S go go-task
+```
+
+## Building
+
+```sh
+go-task build
+```
+
+## Example
+
+```sh
+./bin/bmc-test-go-linux-amd64-v0.0.0 suite -config contrib/example_config.yaml -suite redfish -exec-env local
+```
+
+## Features
+
+- Run tests locally or against a remote BMC over SSH.
+- Connect to the Redfish service over HTTPS.
+- Group tests into suites such as IPMI, Redfish, SMBIOS, and BMC Linux checks.
+- Store platform-specific expectations in a YAML configuration file.
+- Emit either default text logs or structured JSON logs.
+
+## Scope
+
+`bmc-test-go` is intended for platform and integration testing of BMC behavior.
+It is NOT a replacement for Redfish specification conformance tooling.
+
+For Redfish-focused validation, use the DMTF tools:
+
+- [Redfish Service Validator](https://github.com/DMTF/Redfish-Service-Validator):
+  validates a Redfish service against Redfish CSDL schema. The tool is
+  implementation-agnostic and performs `GET` requests to verify responses.
+- [Redfish Interop Validator](https://github.com/DMTF/Redfish-Interop-Validator):
+  validates a Redfish service against a Redfish interoperability profile.
+
+Typical use of `bmc-test-go` is different: it can combine Redfish checks with
+BMC shell commands, host-side checks, firmware update flows, platform-specific
+expectations, and other system behavior that is outside pure Redfish schema or
+profile compliance.
+
+Consider for example checking for the expected asset tracking information or
+sensor count.
+
+
+## Configuration
+
+The test runner expects a YAML configuration file.
+Pass a different configuration file with the command-line configuration option.
+
+Common environment variables:
+
+- `IMAGE`: image under test
+- `GOLDEN_IMAGE`: known-good image used by downgrade or recovery tests
+- `BMC_SSH_KEY`: SSH key for the BMC root user
+- `HOST_SSH_KEY`: SSH key for the host root user
+
+When a configuration field references an environment variable and the expanded
+value is empty, configuration loading fails.
+

--- a/contrib/example_config.yaml
+++ b/contrib/example_config.yaml
@@ -1,11 +1,12 @@
 ---
 version: 0
 name: ExampleServer
-bm_config:
-  bmc_host: bmcIP
-  bmc_user: root
-  bmc_password: 0penBmc
-  ssh_port: "22"
+bmcConfig:
+  host: '10.93.130.125'
+  user: root
+  password: 0penBmc
+  redfishPort: 4443
+  sshPort: "22"
 numHosts: 1
 hosts:
   - host1:
@@ -20,8 +21,11 @@ testdata:
   system:
     guid: guid-string
   cpu:
-    cpuvendor: ""
-    cpumodel: ""
+    - manufacturer: ""
+      model: ""
+      architecture: ""
+      instructionSet: ""
+      type: ""
   voltage:
     - TestString 1
     - TestString 2

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -164,11 +164,21 @@ type Host struct {
 
 // BMC holds the information to connect to the specified BMC.
 type BMC struct {
-	BMCHost     string `yaml:"host"`
-	BMCUser     string `yaml:"user"`
-	BMCPassword string `yaml:"password"`
-	BMCSSHKey   string `yaml:"sshKey"`
-	SSHPort     string `yaml:"sshPort"`
+	BMCHost        string `yaml:"host"`
+	BMCRedfishPort int    `yaml:"redfishPort"`
+	BMCUser        string `yaml:"user"`
+	BMCPassword    string `yaml:"password"`
+	BMCSSHKey      string `yaml:"sshKey"`
+	SSHPort        string `yaml:"sshPort"`
+}
+
+// RedfishPort returns the configured redfish port, fallback to default
+func (b BMC) RedfishPort() int {
+	if b.BMCRedfishPort == 0 {
+		return 443
+	}
+
+	return b.BMCRedfishPort
 }
 
 // Firmware holds the paths for the binary running on the BMC and an golden image for

--- a/pkg/testdevice/bmc.go
+++ b/pkg/testdevice/bmc.go
@@ -3,6 +3,8 @@ package testdevice
 import (
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/9elements/bmc-test-go/pkg/configuration"
 	"github.com/stmcginnis/gofish"
@@ -18,8 +20,10 @@ type BMC struct {
 }
 
 func makeGofishConfig(config *configuration.Config) gofish.ClientConfig {
+	hostport := net.JoinHostPort(config.BMCHost, strconv.Itoa(config.RedfishPort()))
+
 	return gofish.ClientConfig{
-		Endpoint: "https://" + config.BMCHost,
+		Endpoint: "https://" + hostport,
 		Username: config.BMCUser,
 		Password: config.BMCPassword,
 		Insecure: true,

--- a/pkg/tests/redfish/redfish_tests.go
+++ b/pkg/tests/redfish/redfish_tests.go
@@ -621,6 +621,10 @@ func getFirmwareVersion(dev *testdevice.Device) (string, error) {
 
 	log.Printf("Debug: parts: %v\n", parts)
 
+	if len(parts) < 3 {
+		return "", fmt.Errorf("fw version did not split as expected: %s", fw.Version)
+	}
+
 	return parts[2][1:], nil
 }
 


### PR DESCRIPTION
- fix README.md, list dependencies, build instruction, example run
- fix config parser to accept nonstandard redfish port, fallback to default
- fix example config

