### PR TITLE
refactor: unify naming

### DIFF
--- a/contrib/example_config.yaml
+++ b/contrib/example_config.yaml
@@ -6,7 +6,7 @@ bmcConfig:
   user: root
   password: 0penBmc
   redfishPort: 4443
-  sshPort: "22"
+  sshPort: 22
 numHosts: 1
 hosts:
   - host1:

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -159,7 +159,7 @@ type Host struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
 	SSHKey   string `yaml:"sshKey"`
-	SSHPort  string `yaml:"sshPort"`
+	SSHPort  int    `yaml:"sshPort"`
 }
 
 // BMC holds the information to connect to the specified BMC.
@@ -169,7 +169,7 @@ type BMC struct {
 	BMCUser        string `yaml:"user"`
 	BMCPassword    string `yaml:"password"`
 	BMCSSHKey      string `yaml:"sshKey"`
-	SSHPort        string `yaml:"sshPort"`
+	SSHPort        int    `yaml:"sshPort"`
 }
 
 // RedfishPort returns the configured redfish port, fallback to default

--- a/pkg/configuration/validate.go
+++ b/pkg/configuration/validate.go
@@ -38,7 +38,7 @@ func validateCfgBMC(bmc *BMC) error {
 		err = fmt.Errorf("%w\n %w: bmc field 'sshKey'", err, errFieldEmpty)
 	}
 
-	if bmc.SSHPort == "" {
+	if bmc.SSHPort == 0 {
 		err = fmt.Errorf("%w\n %w: bmc field 'sshPort'", err, errFieldEmpty)
 	}
 
@@ -92,7 +92,7 @@ func validateCfgHost(host *Host, num int) error {
 		err = fmt.Errorf("%w\n %w: host%d field 'sshKey'", err, errFieldEmpty, num)
 	}
 
-	if host.SSHPort == "" {
+	if host.SSHPort == 0 {
 		err = fmt.Errorf("%w\n %w: host%d field 'sshPort'", err, errFieldEmpty, num)
 	}
 

--- a/pkg/testdevice/bmc.go
+++ b/pkg/testdevice/bmc.go
@@ -37,7 +37,7 @@ func newBMC(execEnv string, config *configuration.Config) (*BMC, error) {
 	case "local":
 		ret.con = &LocalConn{}
 	case "remote":
-		hostport := fmt.Sprintf("%s:%s", cfg.BMCHost, cfg.SSHPort)
+		hostport := net.JoinHostPort(config.BMCHost, strconv.Itoa(config.SSHPort))
 
 		remoteConn, err := NewRemoteConn(hostport, config.BMCUser, config.BMCPassword)
 		if err != nil {

--- a/pkg/testdevice/bmc.go
+++ b/pkg/testdevice/bmc.go
@@ -30,7 +30,7 @@ func makeGofishConfig(config *configuration.Config) gofish.ClientConfig {
 	}
 }
 
-func newBMC(execEnv string, cfg *configuration.Config) (*BMC, error) {
+func newBMC(execEnv string, config *configuration.Config) (*BMC, error) {
 	ret := &BMC{}
 
 	switch execEnv {
@@ -39,7 +39,7 @@ func newBMC(execEnv string, cfg *configuration.Config) (*BMC, error) {
 	case "remote":
 		hostport := fmt.Sprintf("%s:%s", cfg.BMCHost, cfg.SSHPort)
 
-		remoteConn, err := NewRemoteConn(hostport, cfg.BMCUser, cfg.BMCPassword)
+		remoteConn, err := NewRemoteConn(hostport, config.BMCUser, config.BMCPassword)
 		if err != nil {
 			return nil, err
 		}
@@ -49,7 +49,7 @@ func newBMC(execEnv string, cfg *configuration.Config) (*BMC, error) {
 		return nil, fmt.Errorf("%w: %s", errUnknownConenction, execEnv)
 	}
 
-	conn, err := gofish.Connect(makeGofishConfig(cfg))
+	conn, err := gofish.Connect(makeGofishConfig(config))
 	if err != nil {
 		return nil, fmt.Errorf("gofish connect failed: %w", err)
 	}
@@ -85,8 +85,8 @@ func (b *BMC) RedfishService() *gofish.Service {
 }
 
 // Reconnect reconnects to the bmc.
-func (b *BMC) Reconnect(cfg *configuration.Config) error {
-	conn, err := gofish.Connect(makeGofishConfig(cfg))
+func (b *BMC) Reconnect(config *configuration.Config) error {
+	conn, err := gofish.Connect(makeGofishConfig(config))
 	if err != nil {
 		return fmt.Errorf("reconnect failed: %w", err)
 	}

--- a/pkg/testdevice/host.go
+++ b/pkg/testdevice/host.go
@@ -46,7 +46,7 @@ func newHost(hostCfg configuration.Host) (*Host, error) {
 
 	return &Host{
 		Name:      hostCfg.Name,
-		hostport:  fmt.Sprintf("%s:%s", hostCfg.IP, hostCfg.SSHPort),
+		hostport:  fmt.Sprintf("%s:%d", hostCfg.IP, hostCfg.SSHPort),
 		sshConfig: sshConfig,
 	}, nil
 }


### PR DESCRIPTION
- unify naming of `config` vs `cfg`
- change SSH port to integer, just like the Redfish port
- use `net.JoinHostPort` instead of `fmt.Sprintf`