### PR TITLE
chore: deduplicate test suite list

### DIFF
--- a/cmds/openbmc-tests/main.go
+++ b/cmds/openbmc-tests/main.go
@@ -109,13 +109,10 @@ func listSuites() {
 	logger.Printf("List Suites")
 	logger.Printf("-------------------------------------------------------")
 	logger.Printf("-------------------------------------------------------")
-	logger.Println("ipmi")
-	logger.Println("ipmi-mct")
-	logger.Println("ipmi-twitter")
-	logger.Println("misc")
-	logger.Println("redfish")
-	logger.Println("smbios")
-	logger.Println("bmc-linux")
+
+	for name := range tests.Suites {
+		logger.Println(name)
+	}
 }
 
 func setupSuite(f *flags) (*testdevice.Device, *configuration.Config, error) {

--- a/pkg/tests/README.md
+++ b/pkg/tests/README.md
@@ -1,11 +1,4 @@
 
 # Test suite definition
 
-- ipmi
-- ipmi-mct
-- ipmi-twitter
-- redfish
-- misc
-- smbios
-- bmc-linux
-
+Test Suites are defined in this folder and registered in `tests.go`.

--- a/pkg/tests/tests.go
+++ b/pkg/tests/tests.go
@@ -36,19 +36,20 @@ func AllTests() []*framework.Test {
 	return ret
 }
 
+// Suites is the map of all available test suites
+var Suites = map[string]func() []*framework.Test{
+	"ipmi":         ipmi.GetTests,
+	"ipmi-mct":     ipmi.GetIPMIMCTTests,
+	"ipmi-twitter": ipmi.GetIPMITwitterTests,
+	"redfish":      redfish.GetTests,
+	"misc":         misc.GetTests,
+	"smbios":       smbios.GetTests,
+	"bmc-linux":    bmclinux.GetBMCLinuxTests,
+}
+
 // GetSuite collects the tests of the given suite name.
 func GetSuite(suite string) []*framework.Test {
-	suites := map[string]func() []*framework.Test{
-		"ipmi":         ipmi.GetTests,
-		"ipmi-mct":     ipmi.GetIPMIMCTTests,
-		"ipmi-twitter": ipmi.GetIPMITwitterTests,
-		"redfish":      redfish.GetTests,
-		"misc":         misc.GetTests,
-		"smbios":       smbios.GetTests,
-		"bmc-linux":    bmclinux.GetBMCLinuxTests,
-	}
-
-	ret, ok := suites[suite]
+	ret, ok := Suites[suite]
 	if !ok {
 		log.Printf("unknown suite name: %s", suite)
 


### PR DESCRIPTION
The list of test suites was duplicated in a couple of places, promoting bit-rot / hard to keep in sync.

Consolidate the test suite list into a single map and use that throughout.

Tested: command works as before

```
 ./bin/bmc-test-go-linux-amd64-v0.0.0 list-suites
List Suites
-------------------------------------------------------
-------------------------------------------------------
ipmi-mct
ipmi-twitter
redfish
misc
smbios
bmc-linux
ipmi
```