### PR TITLE
ci: fix duplicate linting jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ permissions:
 jobs:
   commit-lint:
     runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -36,6 +38,8 @@ jobs:
 
   megalinter:
     runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -49,6 +53,8 @@ jobs:
 
   golangci-lint:
     runs-on: ubuntu-latest
+    if: ${{ ! (github.event_name == 'pull_request_review' && github.actor != 'github-actions[bot]') }}
+    # Skip if pull_request_review on PR not made by a bot
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
- the linting jobs were running always on PR push, and on review
- this is OK for PRs made by bots, as the release CI does not actually trigger CI jobs (GitHub feature to prevent infinite loops)
- but this is not OK for PRs made by humans