### PR TITLE
chore: remove unimplemented 'create-cfg' command

### DIFF
--- a/cmds/openbmc-tests/cmdline.go
+++ b/cmds/openbmc-tests/cmdline.go
@@ -14,7 +14,6 @@ const (
 	listTestsCmd  = "list-tests"
 	listSuitesCmd = "list-suites"
 	runCfgCmd     = "run-from-cfg"
-	createCfgCmd  = "create-cfg"
 )
 
 type flags struct {
@@ -97,13 +96,6 @@ func defineRunFromCfgCmdsFlagSet(f *flags) *flag.FlagSet {
 	return runFromCfgFS
 }
 
-func defineCreateCFGCmdFlagSet(f *flags) *flag.FlagSet {
-	createCfgFS := flag.NewFlagSet(createCfgCmd, flag.ExitOnError)
-	createCfgFS.StringVar(&f.configPath, "path", "./", "Path to create config file")
-
-	return createCfgFS
-}
-
 func defineFlagSets(f *flags) map[string]*flag.FlagSet {
 	flagsets := map[string]*flag.FlagSet{
 		cfgCheckCmd:   defineCfgCheckFlagSet(f),
@@ -113,7 +105,6 @@ func defineFlagSets(f *flags) map[string]*flag.FlagSet {
 		listTestsCmd:  defineListTestCmdFlagSet(f),
 		listSuitesCmd: defineListSuitesCmdsFlagSet(),
 		runCfgCmd:     defineRunFromCfgCmdsFlagSet(f),
-		createCfgCmd:  defineCreateCFGCmdFlagSet(f),
 	}
 
 	return flagsets


### PR DESCRIPTION
Since every board is different, and example config is already present, it is unclear what 'create-cfg' should generate that is not already possible by providing example configs.

On top of that this feature was never actually implemented.

Remove the commandline flag to avoid confusing users.

Tested: The command did not work independent of which flag permutation.

```
./bin/bmc-test-go-linux-amd64-v0.0.0 create-cfg
2026/07/06 13:50:24 failed to set up device: loading configuration file failed: failed to read file: read .: is a directory

[alexander@alexanderarchlinux bmc-test-go]$ ./bin/bmc-test-go-linux-amd64-v0.0.0 create-cfg -path contrib/example_config.yaml
2026/07/06 13:52:28 unknown command: create-cfg
```