### PR TITLE
feature: validate example config in CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,3 +25,6 @@ jobs:
       - name: build
         run: |
           task build
+      - name: validate example config
+        run: |
+           ./bin/bmc-test-go-linux-amd64-v0.0.0 cfg-check contrib/example_config.yaml

--- a/cmds/openbmc-tests/main.go
+++ b/cmds/openbmc-tests/main.go
@@ -115,20 +115,6 @@ func listSuites() {
 	}
 }
 
-func setupSuite(f *flags) (*testdevice.Device, *configuration.Config, error) {
-	cfg, err := configuration.LoadConfig(f.configPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("loading configuration file failed: %w", err)
-	}
-
-	bmc, err := testdevice.NewDevice(f.execEnv, f.logType, f.logFile, cfg)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to set up new device: %w", err)
-	}
-
-	return bmc, cfg, nil
-}
-
 func runCfgValidation(cfg *configuration.Config) error {
 	err := configuration.Validate(cfg)
 	if err != nil {
@@ -143,10 +129,10 @@ var (
 	errInvalidArgumentCount = errors.New("invalid argument count")
 )
 
-func runAgainstDevice(f *flags) error {
-	bmc, cfg, err := setupSuite(f)
+func runAgainstDevice(f *flags, cfg *configuration.Config) error {
+	bmc, err := testdevice.NewDevice(f.execEnv, f.logType, f.logFile, cfg)
 	if err != nil {
-		return fmt.Errorf("failed to set up device: %w", err)
+		return fmt.Errorf("failed to set up new device: %w", err)
 	}
 
 	defer func() {
@@ -165,8 +151,6 @@ func runAgainstDevice(f *flags) error {
 		return runAll(bmc, cfg)
 	case runCfgCmd:
 		runFromCfg(bmc, cfg)
-	case cfgCheckCmd:
-		return runCfgValidation(cfg)
 	default:
 		return fmt.Errorf("%w: %s", errUnknownCommand, f.cmd)
 	}
@@ -194,7 +178,16 @@ func run(args []string) error {
 		return nil
 	}
 
-	return runAgainstDevice(flags)
+	cfg, err := configuration.LoadConfig(flags.configPath)
+	if err != nil {
+		return fmt.Errorf("loading configuration file failed: %w", err)
+	}
+
+	if flags.cmd == cfgCheckCmd {
+		return runCfgValidation(cfg)
+	}
+
+	return runAgainstDevice(flags, cfg)
 }
 
 func main() {

--- a/contrib/example_config.yaml
+++ b/contrib/example_config.yaml
@@ -10,16 +10,15 @@ bmcConfig:
 numHosts: 1
 hosts:
   - host1:
+    name: exampleName
+    username: root
     ip: hostIP1
-    user: hostUser1
+    sshPort: 22
     password: hostPassword1
-  - host2:
-    ip: hostIP2
-    user: hostUser2
-    password: hostPassword2
 testdata:
   system:
     guid: guid-string
+  cpuCount: 1
   cpu:
     - manufacturer: ""
       model: ""

--- a/pkg/configuration/validate.go
+++ b/pkg/configuration/validate.go
@@ -27,16 +27,14 @@ func validateCfgBMC(bmc *BMC) error {
 	}
 
 	if bmc.BMCUser == "" {
-		err = fmt.Errorf("%w\n %w: 'bmc field 'host'", err, errFieldEmpty)
+		err = fmt.Errorf("%w\n %w: 'bmc field 'user'", err, errFieldEmpty)
 	}
 
 	if bmc.BMCPassword == "" {
 		err = fmt.Errorf("%w\n %w: bmc field 'password'", err, errFieldEmpty)
 	}
 
-	if bmc.BMCSSHKey == "" {
-		err = fmt.Errorf("%w\n %w: bmc field 'sshKey'", err, errFieldEmpty)
-	}
+	// ssh key may be empty if password is used
 
 	if bmc.SSHPort == 0 {
 		err = fmt.Errorf("%w\n %w: bmc field 'sshPort'", err, errFieldEmpty)
@@ -88,9 +86,7 @@ func validateCfgHost(host *Host, num int) error {
 		err = fmt.Errorf("%w\n %w: host%d field 'password'", err, errFieldEmpty, num)
 	}
 
-	if host.SSHKey == "" {
-		err = fmt.Errorf("%w\n %w: host%d field 'sshKey'", err, errFieldEmpty, num)
-	}
+	// ssh key may be empty if password is used
 
 	if host.SSHPort == 0 {
 		err = fmt.Errorf("%w\n %w: host%d field 'sshPort'", err, errFieldEmpty, num)


### PR DESCRIPTION
validate our example config in CI to make sure it will parse, preventing us from documenting garbage.

Also restructure the command dispatcher to not require making a redfish connection just to validate our configuration.

The validity of a config does not depend on the machine we are testing to be online at the time of checking config.

New flow parses flags, then runs applicable commands if any, for commands requiring config, those are run later.

resolves #36 