### PR TITLE
fix: remove implementation status enum

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -2,8 +2,6 @@
 package framework
 
 import (
-	"errors"
-
 	"github.com/9elements/bmc-test-go/pkg/configuration"
 	"github.com/9elements/bmc-test-go/pkg/testdevice"
 )
@@ -16,32 +14,16 @@ const (
 	ResultNotRun Result = 0 + iota
 	ResultDependencyFailure
 	ResultInternalFailure
-	ResultNotImplemented
 	ResultFail
 	ResultSuccess
 )
 
 func (r Result) String() string {
-	return [...]string{"TESTNOTRUN", "DEPENDENCY_FAILED", "INTERNAL_ERROR", "Not Implemented", "FAIL", "PASS"}[r]
+	return [...]string{"TESTNOTRUN", "DEPENDENCY_FAILED", "INTERNAL_ERROR", "FAIL", "PASS"}[r]
 }
 
 // Status implements a specific type for the implementation status of a test for easy string conversion.
 type Status int
-
-// The following constants indicate the implementation status of a test.
-const (
-	StatusImplemented Status = 0 + iota
-	StatusNotImplemented
-	StatusPartlyImplemented
-)
-
-// ErrNotImplemented serves as the default error returned by functions
-// not being implemented yet.
-var ErrNotImplemented = errors.New("not implemented")
-
-func (s Status) String() string {
-	return [...]string{"Implemented", "Not implemented", "Partly implemented"}[s]
-}
 
 // Test represents a one specific test.
 type Test struct {
@@ -77,10 +59,6 @@ func (t *Test) Run(dev *testdevice.Device, cfg *configuration.Config) bool {
 
 // RunTest is the function which manages the execution of all tests.
 func RunTest(test *Test, dev *testdevice.Device, testCfg *configuration.Config) bool {
-	if test.Status.String() == StatusNotImplemented.String() {
-		return true
-	}
-
 	ret := test.Run(dev, testCfg)
 
 	isError := test.ErrorText != "" || test.Result.String() == ResultFail.String()

--- a/pkg/tests/bmc_linux/bmclinux.go
+++ b/pkg/tests/bmc_linux/bmclinux.go
@@ -11,19 +11,16 @@ func GetBMCLinuxTests() []*framework.Test {
 		{
 			Name:      "BMC Linux Startup health Test",
 			ShortName: "bmc-linux-00",
-			Status:    framework.StatusImplemented,
 			Function:  testBMCLinuxStartupHealth,
 		},
 		{
 			Name:      "BMC Linux Systemctl failed Test",
 			ShortName: "bmc-linux-01",
-			Status:    framework.StatusImplemented,
 			Function:  testBMCLinuxSystemctlFailed,
 		},
 		{
 			Name:      "BMC Linux Systemctl job list Test",
 			ShortName: "bmc-linux-02",
-			Status:    framework.StatusImplemented,
 			Function:  testBMCLinuxSystemctlJobList,
 		},
 	}

--- a/pkg/tests/ipmi/ipmi_tests.go
+++ b/pkg/tests/ipmi/ipmi_tests.go
@@ -22,66 +22,52 @@ func GetTests() []*framework.Test {
 		{
 			Name:      "IPMI Sensor Voltage",
 			ShortName: "ipmi-00",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMISensorsVoltage,
 		},
 
 		{
 			Name:      "IPMI Sensor Temperature",
 			ShortName: "ipmi-01",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMISensorTemperature,
 		},
 
 		{
 			Name:      "IPMI Sensor Fans",
 			ShortName: "ipmi-02",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMISensorFans,
 		},
 
 		{
 			Name:      "IPMI Power Status",
 			ShortName: "ipmi-03",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMIPowerStatus,
 		},
 		{
 			Name:      "IPMI Chassis Uptime",
 			ShortName: "ipmi-04",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMIChassisUptime,
 		},
 		{
 			Name:      "IPMI Fru",
 			ShortName: "ipmi-05",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMIFru,
 		},
 		{
 			Name:      "IPMI DCMI Power Reading",
 			ShortName: "ipmi-06",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMIDCMIPowerReading,
 		},
 		{
 			Name:      "IPMI Watchdog Configuration",
 			ShortName: "ipmi-07",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMIWatchdogConfiguration,
 		},
 		{
 			Name:      "IPMI System GUID",
 			ShortName: "ipmi-08",
-			Status:    framework.StatusImplemented,
 			Function:  testIPMISystemGUID,
 		},
-		{
-			Name:      "IPMI DCMI Power reading",
-			ShortName: "ipmi-9",
-			Status:    framework.StatusImplemented,
-			Function:  nil,
-		},
+		// TODO: "IPMI DCMI Power reading", test
 	}
 }
 

--- a/pkg/tests/ipmi/mct_ipmi_ext_tests.go
+++ b/pkg/tests/ipmi/mct_ipmi_ext_tests.go
@@ -20,84 +20,72 @@ func GetIPMIMCTTests() []*framework.Test {
 		{
 			Name:      "MCP PWM Duty Set",
 			ShortName: "ipmi-mct-00",
-			Status:    framework.StatusImplemented,
 			Function:  testMCTPWMDutySet,
 		},
 
 		{
 			Name:      "MCP PWM Duty Get",
 			ShortName: "ipmi-mct-01",
-			Status:    framework.StatusImplemented,
 			Function:  testMCTPWMDutyGet,
 		},
 
 		{
 			Name:      "MCP Manufacture Mode Get",
 			ShortName: "ipmi-mct-02",
-			Status:    framework.StatusImplemented,
 			Function:  testMCTManufacturModeGet,
 		},
 
 		{
 			Name:      "MCP Manufacture Mode Set",
 			ShortName: "ipmi-mct-03",
-			Status:    framework.StatusImplemented,
 			Function:  testMCTManufacturModeSet,
 		},
 
 		{
 			Name:      "MCP Floor Duty Get",
 			ShortName: "ipmi-mct-04",
-			Status:    framework.StatusImplemented,
 			Function:  testMCTFloorDutyGet,
 		},
 
 		{
 			Name:      "MCP Floor Duty Set",
 			ShortName: "ipmi-mct-05",
-			Status:    framework.StatusImplemented,
 			Function:  testMCTFloorDutySet,
 		},
 
 		{
 			Name:      "MCP Get Fru Field",
 			ShortName: "ipmi-mct-06",
-			Status:    framework.StatusImplemented,
 			Function:  testMCTGetFruField,
 		},
 
 		{
 			Name:      "MCP Set Fru Field",
 			ShortName: "ipmi-mct-07",
-			Status:    framework.StatusImplemented,
 			Function:  testMCTSetFruField,
 		},
 
 		{
 			Name:      "MCP Get Firmware String",
 			ShortName: "ipmi-mct-08",
-			Status:    framework.StatusImplemented,
 			Function:  testGetFirmwareString,
 		},
 
 		{
 			Name:      "MCP Config ECC Leaky bucket set",
 			ShortName: "ipmi-mct-09",
-			Status:    framework.StatusImplemented,
 			Function:  testECCLeakyBucketSet,
 		},
 
 		{
 			Name:      "MCP Config ECC Leaky bucket get",
 			ShortName: "ipmi-mct-10",
-			Status:    framework.StatusImplemented,
 			Function:  testECCLeakyBucketGet,
 		},
 
 		{
 			Name:      "MCP GPIO Status",
 			ShortName: "ipmi-mct-11",
-			Status:    framework.StatusImplemented,
 			Function:  testGPIOStatus,
 		},
 	}
@@ -308,7 +296,8 @@ func testMCTGetFruField(dev *testdevice.Device, cfg *configuration.Config) (
 func testMCTSetFruField(_ *testdevice.Device, _ *configuration.Config) (
 	bool, error, error,
 ) {
-	return false, framework.ErrNotImplemented, nil
+	// TODO: implement
+	return false, fmt.Errorf("test not implemented"), nil
 }
 
 var errUnexpectedFirmwareString = errors.New("unexpected firmware string")

--- a/pkg/tests/ipmi/twitter_ipmi_ext_tests.go
+++ b/pkg/tests/ipmi/twitter_ipmi_ext_tests.go
@@ -19,40 +19,34 @@ func GetIPMITwitterTests() []*framework.Test {
 		{
 			Name:      "Twitter IPMI Ext Set Service",
 			ShortName: "ipmi-twitter-00",
-			Status:    framework.StatusImplemented,
 			Function:  testTwitterIPMIExtSetService,
 		},
 		{
 			Name:      "Twitter IPMI Ext Get Service",
 			ShortName: "ipmi-twitter-01",
-			Status:    framework.StatusImplemented,
 			Function:  testTwitterIPMIExtGetService,
 		},
 		{
 			Name:      "Twitter IPMI Ext Clear CMOS",
 			ShortName: "ipmi-twitter-02",
-			Status:    framework.StatusNotImplemented,
 			Function:  testTwitterIPMIExtClearCMOS,
 		},
 
 		{
 			Name:      "Twitter IPMI Ext Pnm Get Reading",
 			ShortName: "ipmi-twitter-03",
-			Status:    framework.StatusImplemented,
 			Function:  testTwitterIPMIExtPnmGetReading,
 		},
 
 		{
 			Name:      "Twitter IPMI Ext Random Delay AC Restore Power On",
 			ShortName: "ipmi-twitter-04",
-			Status:    framework.StatusImplemented,
 			Function:  testTwitterIPMIExtRandomDelayACRestorePowerOn,
 		},
 
 		{
 			Name:      "Twitter IPMI Ext Get Post Codes",
 			ShortName: "ipmi-twitter-05",
-			Status:    framework.StatusImplemented,
 			Function:  testTwitterIPMIExtGetPostCodes,
 		},
 	}
@@ -100,7 +94,8 @@ func testTwitterIPMIExtGetService(dev *testdevice.Device, _ *configuration.Confi
 func testTwitterIPMIExtClearCMOS(_ *testdevice.Device, _ *configuration.Config) (
 	bool, error, error,
 ) {
-	return true, nil, nil
+	// TODO: implement
+	return false, fmt.Errorf("not implemented"), nil
 }
 
 func testTwitterIPMIExtPnmGetReading(dev *testdevice.Device, _ *configuration.Config) (

--- a/pkg/tests/misc/misc.go
+++ b/pkg/tests/misc/misc.go
@@ -11,31 +11,26 @@ func GetTests() []*framework.Test {
 		{
 			Name:      "Interface USB network device",
 			ShortName: "iface-00",
-			Status:    framework.StatusImplemented,
 			Function:  testUSBNetwork,
 		},
 		{
 			Name:      "Test PCI Device Aspeed",
 			ShortName: "pci-00",
-			Status:    framework.StatusImplemented,
 			Function:  testPCIDeviceAspeed,
 		},
 		{
 			Name:      "SD Card Service",
 			ShortName: "misc-02",
-			Status:    framework.StatusImplemented,
 			Function:  testSDCardDriver,
 		},
 		{
 			Name:      "SD Card Device presence",
 			ShortName: "misc-03",
-			Status:    framework.StatusImplemented,
 			Function:  testSDCardDevicePresent,
 		},
 		{
 			Name:      "SD Card File System Operation",
 			ShortName: "misc-04",
-			Status:    framework.StatusImplemented,
 			Function:  testSDCardFilesystemOps,
 		},
 	}

--- a/pkg/tests/redfish/redfish.go
+++ b/pkg/tests/redfish/redfish.go
@@ -11,90 +11,77 @@ func GetTests() []*framework.Test {
 		{
 			Name:      "Redfish Chassis Test",
 			ShortName: "redfish-00",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishChassis,
 		},
 		{
 			Name:      "Redfish System Test",
 			ShortName: "redfish-01",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishSystem,
 		},
 
 		{
 			Name:      "Redfish Firmware Version",
 			ShortName: "redfish-02",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishGetFirmwareVersion,
 		},
 
 		{
 			Name:      "Redfish Validate PSU Information",
 			ShortName: "redfish-03",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishCheckPowerSupplyInformation,
 		},
 
 		{
 			Name:      "Redfish PSU Voltage Sensor Names",
 			ShortName: "redfish-04",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishVoltagesSensorNames,
 		},
 
 		{
 			Name:      "Redfish PSU Voltage Sensor Values",
 			ShortName: "redfish-05",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishVoltageSensorValueThesholds,
 		},
 
 		{
 			Name:      "Redfish Temperatur Sensor Names",
 			ShortName: "redfish-06",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishTemperatureSensorNames,
 		},
 
 		{
 			Name:      "Redfish Temperatur Sensor Values",
 			ShortName: "redfish-07",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishTemperaturSensorValueThesholds,
 		},
 
 		{
 			Name:      "Redfish Fan Sensor Names",
 			ShortName: "redfish-08",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishThermalFanNames,
 		},
 
 		{
 			Name:      "Redfish Fan Sensor Values",
 			ShortName: "redfish-09",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishThermalFanValues,
 		},
 
 		{
 			Name:      "Redfish Memory",
 			ShortName: "redfish-10",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishMemory,
 		},
 
 		{
 			Name:      "Redfish Processor",
 			ShortName: "redfish-11",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishProcessor,
 		},
 
 		{
 			Name:      "Redfish Firmware Downgrade Update",
 			ShortName: "redfish-12",
-			Status:    framework.StatusImplemented,
 			Function:  testRedfishFirmwareDowngradeUpdate,
 		},
 	}

--- a/pkg/tests/smbios/smbios.go
+++ b/pkg/tests/smbios/smbios.go
@@ -11,49 +11,42 @@ func GetTests() []*framework.Test {
 		{
 			Name:      "Test SMBIOS Baseboard System Vendor",
 			ShortName: "smbios-00",
-			Status:    framework.StatusImplemented,
 			Function:  testSMBIOSBaseboardSystemVendor,
 		},
 
 		{
 			Name:      "Test SMBIOS Baseboard Product Name",
 			ShortName: "smbios-01",
-			Status:    framework.StatusImplemented,
 			Function:  testSMBIOSBaseboardProductName,
 		},
 
 		{
 			Name:      "Test SMBIOS Baseboard Product Version",
 			ShortName: "smbios-02",
-			Status:    framework.StatusImplemented,
 			Function:  testSMBIOSBaseboardProductVersion,
 		},
 
 		{
 			Name:      "Test SMBIOS Baseboard Product Serial",
 			ShortName: "smbios-03",
-			Status:    framework.StatusImplemented,
 			Function:  testSMBIOSBaseboardProductSerial,
 		},
 
 		{
 			Name:      "Test SMBIOS Baseboard Board Vendor",
 			ShortName: "smbios-04",
-			Status:    framework.StatusImplemented,
 			Function:  testSMBIOSBaseboardBoardVendor,
 		},
 
 		{
 			Name:      "Test SMBIOS Baseboard Board Name",
 			ShortName: "smbios-05",
-			Status:    framework.StatusImplemented,
 			Function:  testSMBIOSBaseboardBoardName,
 		},
 
 		{
 			Name:      "Test SMBIOS Baseboard Board Serial",
 			ShortName: "smbios-06",
-			Status:    framework.StatusImplemented,
 			Function:  testSMBIOSBaseboardBoardSerial,
 		},
 	}


### PR DESCRIPTION
There is no need for this application to store the implementation status of planned work. Testcases can be implemented and merged, we do not need to merge or manage 'unimplemented' things.

Tested: run redfish tests against qemu catalina, output as expected.