### PR TITLE
feat: version flag support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,4 +27,4 @@ jobs:
           task build
       - name: validate example config
         run: |
-          ./bin/bmc-test-go-linux-amd64-v0.0.0 cfg-check contrib/example_config.yaml
+          ./bin/bmc-test-go-amd64 cfg-check contrib/example_config.yaml

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ go-task build
 ## Example
 
 ```sh
-./bin/bmc-test-go-linux-amd64-v0.0.0 suite -config contrib/example_config.yaml -suite redfish -exec-env local
+./bin/bmc-test-go-amd64 suite -config contrib/example_config.yaml -suite redfish -exec-env local
 ```
 
 ## Features

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,9 +10,8 @@ tasks:
       # For Matrix build a Taskfile v3.39.0 or newer is needed
       - for:
           matrix:
-            OS: ['linux']
             ARCH: ['amd64', 'arm', 'arm64']
-        cmd: GOOS="{{.ITEM.OS}}" GOARCH="{{.ITEM.ARCH}}" go build -ldflags="-s -w" -o "bin/bmc-test-go-{{.ITEM.OS}}-{{.ITEM.ARCH}}-{{.SEMVER}}" ./cmds/openbmc-tests
+        cmd: GOOS="linux" GOARCH="{{.ITEM.ARCH}}" go build -ldflags="-s -w -X main.version={{.SEMVER}}" -o "bin/bmc-test-go-{{.ITEM.ARCH}}" ./cmds/openbmc-tests
 
   lint:
     desc: Run linters

--- a/cmds/openbmc-tests/cmdline.go
+++ b/cmds/openbmc-tests/cmdline.go
@@ -14,6 +14,7 @@ const (
 	listTestsCmd  = "list-tests"
 	listSuitesCmd = "list-suites"
 	runCfgCmd     = "run-from-cfg"
+	versionCmd    = "version"
 )
 
 type flags struct {
@@ -96,6 +97,10 @@ func defineRunFromCfgCmdsFlagSet(f *flags) *flag.FlagSet {
 	return runFromCfgFS
 }
 
+func defineVersionFlagSet() *flag.FlagSet {
+	return flag.NewFlagSet(versionCmd, flag.ExitOnError)
+}
+
 func defineFlagSets(f *flags) map[string]*flag.FlagSet {
 	flagsets := map[string]*flag.FlagSet{
 		cfgCheckCmd:   defineCfgCheckFlagSet(f),
@@ -105,6 +110,7 @@ func defineFlagSets(f *flags) map[string]*flag.FlagSet {
 		listTestsCmd:  defineListTestCmdFlagSet(f),
 		listSuitesCmd: defineListSuitesCmdsFlagSet(),
 		runCfgCmd:     defineRunFromCfgCmdsFlagSet(f),
+		versionCmd:    defineVersionFlagSet(),
 	}
 
 	return flagsets

--- a/cmds/openbmc-tests/main.go
+++ b/cmds/openbmc-tests/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/9elements/bmc-test-go/pkg/tests"
 )
 
+var version = "dev"
+
 var errNoTestsToExecute = errors.New("no tests to execute")
 
 func runAll(dev *testdevice.Device, cfg *configuration.Config) error {
@@ -115,6 +117,11 @@ func listSuites() {
 	}
 }
 
+func runVersionCmd() {
+	logger := log.New(os.Stdout, "", log.Lmsgprefix)
+	logger.Printf("%s", version)
+}
+
 func runCfgValidation(cfg *configuration.Config) error {
 	err := configuration.Validate(cfg)
 	if err != nil {
@@ -174,7 +181,9 @@ func run(args []string) error {
 		return listTests(flags.suite)
 	case listSuitesCmd:
 		listSuites()
-
+		return nil
+	case versionCmd:
+		runVersionCmd()
 		return nil
 	}
 


### PR DESCRIPTION
instead of bloating up the binary name with version and OS information, provide version information as a flag.

OS information can easily be gathered with common tools like `file`, no need to stuff it into the filename. This was completely out of line with what other projects do.

```
bin/bmc-test-go-amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=7dNdX1cQr7xzUZHL4gj3/F8n5xt_KR5qHJfBFYA9Y/HRRD_O4NH6S6tVNeETI2/TSBdac4sNXwFYYx9-knI, BuildID[sha1]=1031f778ba6a0ac0a4c3b99ecc03ecb4a50a5360, stripped
```

Tested:

```
$ ./bin/bmc-test-go-amd64 version
v0.0.0
```