### PR TITLE
ci(lint): ignore GO-2026-5932

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,11 +49,15 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v7
+        with:
+          go-version: stable
       - name: MegaLinter
         uses: oxsecurity/megalinter/flavors/cupcake@v9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: true
+          GOTOOLCHAIN: auto
 
   golangci-lint:
     runs-on: ubuntu-latest

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -33,7 +33,3 @@ ACTION_ZIZMOR_DISABLE_ERRORS: true
 
 # Golang
 GO_REVIVE_ARGUMENTS: ./...
-
-# Downgrate to warning because upstream problems that are out of our control
-REPOSITORY_TRIVY_DISABLE_ERRORS: true
-REPOSITORY_OSV_SCANNER_DISABLE_ERRORS: true

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Golang indirect depedency golang.org/x/crypto is unmaintained. But we do not really use any crypto stuff.
+GO-2026-5932

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "Indirect depedency, and we do not use any crypto"


### PR DESCRIPTION
- instead of ignoring all vulnerabilities in supply chain, only ignore this specific vulnerability
- it is in indirect dependency, and therefore hard to fix for us